### PR TITLE
出来事一覧の検索処理修正

### DIFF
--- a/src/main/java/com/example/sortquiz/controller/QuizRestController.java
+++ b/src/main/java/com/example/sortquiz/controller/QuizRestController.java
@@ -84,11 +84,10 @@ public class QuizRestController {
             @RequestParam (required = false) Long yearMin,
             @RequestParam (required = false) Long yearMax
     ) {
-
         QuizSearchForm form = new QuizSearchForm();
         form.setKeyword(keyword);
         form.setYearMin(yearMin == null ? 0 : yearMin);
-        form.setYearMax(yearMax == null ? 0 : 2025);
+        form.setYearMax(yearMax == null ? 2025 : yearMax);
         return quizApiService.getQuizzesByKeywordAndYear(form);
     }
 

--- a/src/main/resources/templates/quiz/quiz-history.html
+++ b/src/main/resources/templates/quiz/quiz-history.html
@@ -62,6 +62,7 @@
         const keyword = searchForm.querySelector('#keyword')
         const yearMin = document.querySelector('#year-min')
         const yearMax = document.querySelector('#year-max')
+        historyList.style.display = 'none'
         const params = new URLSearchParams()
         params.append('keyword', keyword.value)
         if (yearMin.value === undefined || yearMin.value === null || yearMin.value === "") {

--- a/src/main/resources/templates/quiz/quiz-history.html
+++ b/src/main/resources/templates/quiz/quiz-history.html
@@ -64,12 +64,14 @@
         const yearMax = document.querySelector('#year-max')
         const params = new URLSearchParams()
         params.append('keyword', keyword.value)
-        if (yearMin !== undefined && yearMin !== null && yearMin !== "") {
-            params.append('yearMin', yearMin.value)
+        if (yearMin.value === undefined || yearMin.value === null || yearMin.value === "") {
+            yearMin.value = 0
         }
-        if (yearMax !== undefined && yearMax !== null && yearMax !== "") {
-            params.append('yearMax', yearMax.value)
+        params.append('yearMin', yearMin.value)
+        if (yearMax.value === undefined || yearMax.value === null || yearMax.value === "") {
+            yearMax.value = 2025
         }
+        params.append('yearMax', yearMax.value)
         historyList.innerHTML = ''
 
         await fetch(`api/search?${params.toString()}`, {


### PR DESCRIPTION
- controllerでyearMaxが自動で2025入るようになっていたため修正
- 検索欄のyearMinとyearMaxがからの場合、初期値の0と2025が入るように修正
- 検索結果欄の表示処理の修正