### PR TITLE
リザルト画面で称号獲得のトーストの実装

### DIFF
--- a/src/main/java/com/example/sortquiz/controller/QuizRestController.java
+++ b/src/main/java/com/example/sortquiz/controller/QuizRestController.java
@@ -60,7 +60,7 @@ public class QuizRestController {
 //        ベストスコア、総スコアの更新
         userService.updateUserScoreByUserId(userDetails.getUserId());
 //        アチーブメント更新処理
-        titleService.updateAchievedTitle(userDetails.getUserId());
+        List<Long> achieveTitles = titleService.updateAchievedTitle(userDetails.getUserId());
 
 //        問題ごとのデータ(回答・正答・解説)
         List<AnswerViewModel> quizResults = quizService.getQuizDetails(quizForm.getAnswers(), correctAnswer, results);
@@ -69,6 +69,7 @@ public class QuizRestController {
         httpSession.setAttribute("score", scoreCalculated);
         httpSession.setAttribute("time", answerTime);
         httpSession.setAttribute("quizResults", quizResults);
+        httpSession.setAttribute("achievedTitles", achieveTitles);
 
 //        並び替え前のクイズのセッションを破棄
         httpSession.removeAttribute("quizList");

--- a/src/main/java/com/example/sortquiz/controller/TitleRestController.java
+++ b/src/main/java/com/example/sortquiz/controller/TitleRestController.java
@@ -1,0 +1,35 @@
+package com.example.sortquiz.controller;
+
+import com.example.sortquiz.entity.Title;
+import com.example.sortquiz.response.TitleResponse;
+import com.example.sortquiz.security.CustomUserDetails;
+import com.example.sortquiz.service.TitleService;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/quiz/api")
+public class TitleRestController {
+    private final TitleService titleService;
+
+    public TitleRestController(TitleService titleService) {
+        this.titleService = titleService;
+    }
+
+    @GetMapping("/achieveTitle")
+    public ResponseEntity<TitleResponse> getAchieveTitle(HttpSession httpSession,
+                                                         CustomUserDetails userDetails) {
+//        セッションから達成称号を受け取る
+        List<Long> achievedTitleId = (List<Long>) httpSession.getAttribute("achievedTitles");
+//        titleIdから称号のデータを受け取る
+        List<Title> titleList = titleService.getTitlesByTitleId(achievedTitleId);
+        TitleResponse response = new TitleResponse();
+        response.setAchievedTitles(titleList);
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/com/example/sortquiz/controller/TitleRestController.java
+++ b/src/main/java/com/example/sortquiz/controller/TitleRestController.java
@@ -28,6 +28,7 @@ public class TitleRestController {
         List<Long> achievedTitleId = (List<Long>) httpSession.getAttribute("achievedTitles");
 //        titleIdから称号のデータを受け取る
         List<Title> titleList = titleService.getTitlesByTitleId(achievedTitleId);
+//        List<Title> titleList = titleService.getTitles();
         TitleResponse response = new TitleResponse();
         response.setAchievedTitles(titleList);
         return ResponseEntity.ok().body(response);

--- a/src/main/java/com/example/sortquiz/mapper/TitleMapper.java
+++ b/src/main/java/com/example/sortquiz/mapper/TitleMapper.java
@@ -32,4 +32,7 @@ public interface TitleMapper {
     @Insert("INSERT INTO user_titles (user_id, title_id) VALUES (#{userId}, #{titleId})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void createUserTitle(UserTitle userTitle);
+
+    @Select("SELECT * FROM titles WHERE title_id = #{titleId}")
+    Title selectTitleByTitleId(long titleId);
 }

--- a/src/main/java/com/example/sortquiz/repository/TitleRepository.java
+++ b/src/main/java/com/example/sortquiz/repository/TitleRepository.java
@@ -34,5 +34,9 @@ public class TitleRepository {
     public void createUserTitle(UserTitle userTitle) {
         titleMapper.createUserTitle(userTitle);
     }
+
+    public Title selectTitleByTitleId(long titleId) {
+        return titleMapper.selectTitleByTitleId(titleId);
+    }
 }
 

--- a/src/main/java/com/example/sortquiz/response/TitleResponse.java
+++ b/src/main/java/com/example/sortquiz/response/TitleResponse.java
@@ -1,0 +1,11 @@
+package com.example.sortquiz.response;
+
+import com.example.sortquiz.entity.Title;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TitleResponse {
+    private List<Title> achievedTitles;
+}

--- a/src/main/java/com/example/sortquiz/service/TitleService.java
+++ b/src/main/java/com/example/sortquiz/service/TitleService.java
@@ -89,4 +89,12 @@ public class TitleService {
         }
         return achieveTitles;
     }
+
+    public List<Title> getTitlesByTitleId(List<Long> titles) {
+        List<Title> titleList = new ArrayList<>();
+        for (long titleId : titles) {
+            titleList.add(titleRepository.selectTitleByTitleId(titleId));
+        }
+        return titleList;
+    }
 }

--- a/src/main/java/com/example/sortquiz/service/TitleService.java
+++ b/src/main/java/com/example/sortquiz/service/TitleService.java
@@ -10,6 +10,7 @@ import com.example.sortquiz.viewmodel.AchievedTitleViewModel;
 import com.example.sortquiz.viewmodel.ScoreHistoryViewModel;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -32,7 +33,8 @@ public class TitleService {
         return titleRepository.getUserTitles(userId);
     }
 
-    public void updateAchievedTitle(long userId) {
+    public List<Long> updateAchievedTitle(long userId) {
+        List<Long> achieveTitles = new ArrayList<>();
 //        取得状況も含めた称号一覧を取得する
         List<AchievedTitleViewModel> achievedTitles = titleRepository.selectAchievedTitleByUserId(userId);
 //        プレイ履歴(スコア履歴)を取得する
@@ -49,6 +51,7 @@ public class TitleService {
                 userTitle.setTitleId(1);
                 titleRepository.createUserTitle(userTitle);
                 System.out.println("達成："+achievedTitles.get(0).getTitle());
+                achieveTitles.add(1L);
             }
         }
 
@@ -58,6 +61,7 @@ public class TitleService {
                 userTitle.setTitleId(2);
                 titleRepository.createUserTitle(userTitle);
                 System.out.println("達成："+achievedTitles.get(1).getTitle());
+                achieveTitles.add(2L);
             }
         }
 
@@ -67,6 +71,7 @@ public class TitleService {
                 userTitle.setTitleId(3);
                 titleRepository.createUserTitle(userTitle);
                 System.out.print("達成："+achievedTitles.get(2).getTitle());
+                achieveTitles.add(3L);
             }
         }
 
@@ -77,9 +82,11 @@ public class TitleService {
                     userTitle.setTitleId(4);
                     titleRepository.createUserTitle(userTitle);
                     System.out.print("達成："+achievedTitles.get(3).getTitle());
+                    achieveTitles.add(4L);
                     break;
                 }
             }
         }
+        return achieveTitles;
     }
 }

--- a/src/main/resources/static/css/quiz-result.css
+++ b/src/main/resources/static/css/quiz-result.css
@@ -227,3 +227,40 @@ details[open] {
         grid-template-columns: 1fr;
     }
 }
+
+.toast {
+    visibility: hidden;
+    min-width: 250px;
+    margin-left: -125px;
+    background-color: #333;
+    color: #fff;
+    text-align: center;
+    border-radius: 5px;
+    padding: 16px;
+    position: fixed;
+    z-index: 10;
+    left: 50%;
+    bottom: 30px;
+    font-size: 17px;
+}
+.toast.show {
+    visibility: visible;
+    animation: fadein 0.5s forwards, fadeout 0.5s 2.5s forwards;
+}
+@keyframes fadein {
+    from {
+        bottom: 0; opacity: 0;
+    }
+    to {
+        bottom: 30px; opacity: 1;
+    }
+}
+
+@keyframes fadeout {
+    from {
+        bottom: 30px; opacity: 1;
+    }
+    to {
+        bottom: 0; opacity: 0;
+    }
+}

--- a/src/main/resources/static/css/quiz-result.css
+++ b/src/main/resources/static/css/quiz-result.css
@@ -232,17 +232,29 @@ details[open] {
     visibility: hidden;
     min-width: 250px;
     margin-left: -125px;
-    background-color: #333;
-    color: #fff;
+    background: linear-gradient(135deg, #5b4636, #3c2f25); /* 古風な革や紙の色合い */
+    color: #f5f1e6; /* parchment 風の文字色 */
     text-align: center;
-    border-radius: 5px;
-    padding: 16px;
+    border-radius: 8px;
+    padding: 14px 18px;
     position: fixed;
     z-index: 10;
     left: 50%;
     bottom: 30px;
     font-size: 17px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4),
+    inset 0 0 8px rgba(255, 255, 255, 0.1);
+    border: 2px solid #d4af37;
+    letter-spacing: 1px;
+    display: flex;
+    flex-direction: column;
 }
+
+.toast-title {
+    color: #D4AF37;
+    margin-bottom: 12px;
+}
+
 .toast.show {
     visibility: visible;
     animation: fadein 0.5s forwards, fadeout 0.5s 2.5s forwards;

--- a/src/main/resources/templates/quiz/quiz-result.html
+++ b/src/main/resources/templates/quiz/quiz-result.html
@@ -92,6 +92,11 @@
 
     //     称号獲得
         const toastTitle = document.querySelector("#toast_title")
+        function removeToast(item) {
+            setTimeout(() => {
+                item.remove()
+            }, 3000)
+        }
         async function getAchieveTitles() {
             await fetch("api/achieveTitle", {
                 method: 'GET',
@@ -103,17 +108,21 @@
                 .then(res => res.json())
                 .then(result => {
                     if (result.achievedTitles.length >= 1) {
-                        result.achievedTitles.forEach(item => {
-                            console.log('toast')
-                            const toast = document.createElement('div')
-                            toast.className = 'toast show'
-                            toast.innerHTML = `
-                            <div>${item.title}:${item.description}</div>
-                            `
-                            toastTitle.appendChild(toast)
+                        result.achievedTitles.forEach((item, index) => {
                             setTimeout(() => {
-                                toast.remove()
-                            }, 3000)
+                                console.log('toast')
+                                const toast = document.createElement('div')
+                                toast.className = 'toast show'
+                                toast.innerHTML = `
+                                <div class="toast-title">称号獲得</div>
+                                <div>${item.title}:${item.description}</div>
+                                `
+                                toastTitle.appendChild(toast)
+                                removeToast(toast)
+                                // setTimeout(() => {
+                                //     toast.remove()
+                                // }, 3000)
+                            }, index * 3500)
                         })
                     }
                 })

--- a/src/main/resources/templates/quiz/quiz-result.html
+++ b/src/main/resources/templates/quiz/quiz-result.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" href="/css/quiz-result.css">
     <title>結果</title>
+    <meta name="_csrf" th:content="${_csrf.token}">
+    <meta name="_csrf_header" th:content="${_csrf.headerName}">
 </head>
 <body>
     <section>
@@ -75,7 +77,11 @@
         <a th:href="@{/quiz}" id="back-top">トップに戻る</a>
     </div>
 
+    <div id="toast_title" class="toast">操作が完了しました</div>
+
     <script>
+        const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute("content")
+        const csrfHeader = document.querySelector('meta[name="_csrf_header"]').getAttribute("content")
         //↑が押されたとき
         document.getElementById("back-to-top").addEventListener("click", () => {
             window.scrollTo({
@@ -83,6 +89,36 @@
                 behavior: "smooth" // 滑らかにスクロール
             });
         });
+
+    //     称号獲得
+        const toastTitle = document.querySelector("#toast_title")
+        async function getAchieveTitles() {
+            await fetch("api/achieveTitle", {
+                method: 'GET',
+                headers: {
+                    [csrfHeader]: csrfToken,
+                    'Content-Type': 'application/json',
+                },
+            })
+                .then(res => res.json())
+                .then(result => {
+                    if (result.achievedTitles.length >= 1) {
+                        result.achievedTitles.forEach(item => {
+                            console.log('toast')
+                            const toast = document.createElement('div')
+                            toast.className = 'toast show'
+                            toast.innerHTML = `
+                            <div>${item.title}:${item.description}</div>
+                            `
+                            toastTitle.appendChild(toast)
+                            setTimeout(() => {
+                                toast.remove()
+                            }, 3000)
+                        })
+                    }
+                })
+        }
+        getAchieveTitles()
     </script>
 </body>
 </html>


### PR DESCRIPTION
- 新たに獲得する称号をセッションに保存
- 称号のデータをapiを用いて渡す
- トーストの表示処理の実装